### PR TITLE
feat: multilingual proofreading support (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This extension bridges the gap by leveraging large language models (LLMs). It ch
 - **Synonym recommendations** for better word choices  
 - **Configurable system prompts** to customize language variant, writing style, and behavior
 - **Configurable Ollama models** to use any local model that fits your needs and hardware
+- **Multilingual checking** in any language the model supports, selectable via a quick command
 
 ## Getting Started
 
@@ -42,8 +43,10 @@ When the first command is executed, a dialog appears allowing users to select ei
   Rewrites the selected text for clarity.
 - **"LLM writing tool: Get synonyms for selection"**
   Suggests synonyms for the selected expression.
-- **"LLM writing tool: Select model"**
+- **"LLM writing tool: Select model"**  
   Selects the LLM model to use for grammar checking. Stops real-time grammar checking if it is running.
+- **"LLM writing tool: Select language"**
+  Selects the language used for proofreading, rewriting, and synonyms. Choose from common languages or enter your own.
 - **"LLM writing tool: Reset prompts to defaults"**
   Resets all customized system prompts back to their default values.
 - **"LLM writing tool: Reset all settings to defaults"**
@@ -94,6 +97,11 @@ When customizing prompts, use these placeholders:
 
 - `{text}` - The text to be processed (for proofreading and rewrite prompts)
 - `{expression}` - The selected expression (for synonyms prompt)
+- `{language}` - The language configured via `lmWritingTool.language` (e.g. "British English", "German")
+
+### Language
+
+By default the tool checks and writes in American English. To switch languages, either run the **"LLM writing tool: Select language"** command (choose from common languages or enter your own) or set `lmWritingTool.language` directly. Most modern LLMs are multilingual, so the same model can proofread many languages. The default prompts insert this value via the `{language}` placeholder, so changing the language does not require editing prompts.
 
 ### Example Customizations
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
         "title": "LLM writing tool: Select model"
       },
       {
+        "command": "lm-writing-tool.selectLanguage",
+        "title": "LLM writing tool: Select language"
+      },
+      {
         "command": "lm-writing-tool.resetPrompts",
         "title": "LLM writing tool: Reset prompts to defaults"
       },
@@ -57,20 +61,25 @@
     "configuration": {
       "title": "LLM Writing Tool",
       "properties": {
+        "lmWritingTool.language": {
+          "type": "string",
+          "default": "American English",
+          "description": "The language to proofread, rewrite, and find synonyms in. Used by the default prompts via the {language} placeholder. Set it quickly with the 'LLM writing tool: Select language' command. Examples: 'British English', 'German', 'French'."
+        },
         "lmWritingTool.prompts.proofreading": {
           "type": "string",
-          "default": "Proofread the following message in American English. If it is gramatically correct, just respond with the word \"Correct\". If it is gramatically incorrect or has spelling mistakes, respond with \"Correction: \", followed by the corrected version. If you make a correction, write the whole corrected text, not just the segments with corrections. Do not add additional text or explanations. Do not change special commands, code, escape characters, or mathematical formulas. Only correct grammatical issues, do not change the content:\n{text}",
-          "description": "System prompt for proofreading text. Use {text} as a placeholder for the text to be proofread."
+          "default": "Proofread the following message in {language}. If it is gramatically correct, just respond with the word \"Correct\". If it is gramatically incorrect or has spelling mistakes, respond with \"Correction: \", followed by the corrected version. If you make a correction, write the whole corrected text, not just the segments with corrections. Do not add additional text or explanations. Do not change special commands, code, escape characters, or mathematical formulas. Only correct grammatical issues, do not change the content:\n{text}",
+          "description": "System prompt for proofreading text. Use {text} as a placeholder for the text to be proofread and {language} for the configured language."
         },
         "lmWritingTool.prompts.rewrite": {
           "type": "string",
-          "default": "Rewrite the following text for clarity in American English. Do not change special commands, code, escape characters, or mathematical formulas. Respond just with the rewritten version of the text, no extra explanation:\n{text}",
-          "description": "System prompt for rewriting text. Use {text} as a placeholder for the text to be rewritten."
+          "default": "Rewrite the following text for clarity in {language}. Do not change special commands, code, escape characters, or mathematical formulas. Respond just with the rewritten version of the text, no extra explanation:\n{text}",
+          "description": "System prompt for rewriting text. Use {text} as a placeholder for the text to be rewritten and {language} for the configured language."
         },
         "lmWritingTool.prompts.synonyms": {
           "type": "string",
-          "default": "Give up to 5 synonyms for the expression \"{expression}\". Just respond with the synonyms, separated by newlines. No extra explanation or context needed.",
-          "description": "System prompt for finding synonyms. Use {expression} as a placeholder for the expression to find synonyms for."
+          "default": "Give up to 5 synonyms in {language} for the expression \"{expression}\". Just respond with the synonyms, separated by newlines. No extra explanation or context needed.",
+          "description": "System prompt for finding synonyms. Use {expression} as a placeholder for the expression to find synonyms for and {language} for the configured language."
         },
         "lmWritingTool.ollama.model": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "lmWritingTool.language": {
           "type": "string",
           "default": "American English",
+          "scope": "window",
           "description": "The language to proofread, rewrite, and find synonyms in. Used by the default prompts via the {language} placeholder. Set it quickly with the 'LLM writing tool: Select language' command. Examples: 'British English', 'German', 'French'."
         },
         "lmWritingTool.prompts.proofreading": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -404,6 +404,18 @@ export async function activate(context: vscode.ExtensionContext) {
 		return _lmwt;
 	}
 
+	// Drop cached results, pending requests, and shown squiggles so checking restarts fresh
+	// (e.g. after the language changes). The running text-check interval re-requests as needed.
+	function invalidateDiagnostics() {
+		if (!_lmwt) {
+			return;
+		}
+		_lmwt.taskScheduler.abortAll();
+		_lmwt.diagnosticsCache.clear();
+		_lmwt.corrections.clear();
+		_lmwt.dc.clear();
+	}
+
 	async function selectModel() {
 		const models = await vscode.lm.selectChatModels({
 			vendor: 'copilot',
@@ -592,7 +604,9 @@ export async function activate(context: vscode.ExtensionContext) {
 				}
 				language = custom.trim();
 			}
-			const cfg = vscode.workspace.getConfiguration('lmWritingTool');
+			// Scope the config to the active document so multi-root workspaces update the right folder.
+			const resource = vscode.window.activeTextEditor?.document.uri;
+			const cfg = vscode.workspace.getConfiguration('lmWritingTool', resource);
 			// Write to the scope that is currently in effect so the change is actually applied.
 			const inspected = cfg.inspect<string>('language');
 			let target = vscode.ConfigurationTarget.Global;
@@ -602,9 +616,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				target = vscode.ConfigurationTarget.Workspace;
 			}
 			await cfg.update('language', language, target);
-			if (_lmwt) {
-				_lmwt.diagnosticsCache.clear();
-			}
+			invalidateDiagnostics();
 			vscode.window.showInformationMessage(`LLM Writing Tool language set to: ${language}`);
 		})
 	);
@@ -638,10 +650,8 @@ export async function activate(context: vscode.ExtensionContext) {
 			// Reset language to default
 			await vscode.workspace.getConfiguration('lmWritingTool').update('language', undefined, vscode.ConfigurationTarget.Global);
 
-			// Clear cached diagnostics so they are recomputed with the restored language.
-			if (_lmwt) {
-				_lmwt.diagnosticsCache.clear();
-			}
+			// Discard cached results and pending work so they are recomputed with the restored language.
+			invalidateDiagnostics();
 
 			vscode.window.showInformationMessage('All extension settings have been reset to their default values');
 		})

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -585,13 +585,23 @@ export async function activate(context: vscode.ExtensionContext) {
 				const custom = await vscode.window.showInputBox({
 					prompt: 'Enter the language to use (e.g. "Brazilian Portuguese")',
 					placeHolder: 'Language',
+					validateInput: (value) => value.trim().length === 0 ? 'Please enter a language' : undefined,
 				});
-				if (!custom) {
+				if (custom === undefined || custom.trim().length === 0) {
 					return;
 				}
 				language = custom.trim();
 			}
-			await vscode.workspace.getConfiguration('lmWritingTool').update('language', language, vscode.ConfigurationTarget.Global);
+			const cfg = vscode.workspace.getConfiguration('lmWritingTool');
+			// Write to the scope that is currently in effect so the change is actually applied.
+			const inspected = cfg.inspect<string>('language');
+			let target = vscode.ConfigurationTarget.Global;
+			if (inspected?.workspaceFolderValue !== undefined) {
+				target = vscode.ConfigurationTarget.WorkspaceFolder;
+			} else if (inspected?.workspaceValue !== undefined) {
+				target = vscode.ConfigurationTarget.Workspace;
+			}
+			await cfg.update('language', language, target);
 			if (_lmwt) {
 				_lmwt.diagnosticsCache.clear();
 			}
@@ -627,6 +637,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
 			// Reset language to default
 			await vscode.workspace.getConfiguration('lmWritingTool').update('language', undefined, vscode.ConfigurationTarget.Global);
+
+			// Clear cached diagnostics so they are recomputed with the restored language.
+			if (_lmwt) {
+				_lmwt.diagnosticsCache.clear();
+			}
 
 			vscode.window.showInformationMessage('All extension settings have been reset to their default values');
 		})

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -604,17 +604,13 @@ export async function activate(context: vscode.ExtensionContext) {
 				}
 				language = custom.trim();
 			}
-			// Scope the config to the active document so multi-root workspaces update the right folder.
-			const resource = vscode.window.activeTextEditor?.document.uri;
-			const cfg = vscode.workspace.getConfiguration('lmWritingTool', resource);
-			// Write to the scope that is currently in effect so the change is actually applied.
+			// The language is a window-scoped preference. Write to the workspace if it is
+			// already overridden there, otherwise to the user (global) settings.
+			const cfg = vscode.workspace.getConfiguration('lmWritingTool');
 			const inspected = cfg.inspect<string>('language');
-			let target = vscode.ConfigurationTarget.Global;
-			if (inspected?.workspaceFolderValue !== undefined) {
-				target = vscode.ConfigurationTarget.WorkspaceFolder;
-			} else if (inspected?.workspaceValue !== undefined) {
-				target = vscode.ConfigurationTarget.Workspace;
-			}
+			const target = inspected?.workspaceValue !== undefined
+				? vscode.ConfigurationTarget.Workspace
+				: vscode.ConfigurationTarget.Global;
 			await cfg.update('language', language, target);
 			invalidateDiagnostics();
 			vscode.window.showInformationMessage(`LLM Writing Tool language set to: ${language}`);
@@ -673,6 +669,16 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.window.onDidChangeActiveTextEditor(() => {
 			updateTextCheckStatusBar();
+		})
+	);
+
+	// Recompute diagnostics when language or prompts change (e.g. via the Settings UI),
+	// since cached results depend on these values.
+	context.subscriptions.push(
+		vscode.workspace.onDidChangeConfiguration((event) => {
+			if (event.affectsConfiguration('lmWritingTool.language') || event.affectsConfiguration('lmWritingTool.prompts')) {
+				invalidateDiagnostics();
+			}
 		})
 	);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,25 +72,30 @@ class LMWritingTool {
 		//this.lmCallback = lmCallback;
 	}
 
+	private getLanguage(): string {
+		const config = vscode.workspace.getConfiguration('lmWritingTool');
+		return config.get<string>('language') || 'American English';
+	}
+
 	private getProofreadingPrompt(text: string): string {
 		const config = vscode.workspace.getConfiguration('lmWritingTool.prompts');
 		const template = config.get<string>('proofreading') ||
-			'Proofread the following message in American English. If it is gramatically correct, just respond with the word "Correct". If it is gramatically incorrect or has spelling mistakes, respond with "Correction: ", followed by the corrected version. If you make a correction, write the whole corrected text, not just the segments with corrections. Do not add additional text or explanations. Do not change special commands, code, escape characters, or mathematical formulas. Only correct grammatical issues, do not change the content:\n{text}';
-		return template.replace('{text}', text);
+			'Proofread the following message in {language}. If it is gramatically correct, just respond with the word "Correct". If it is gramatically incorrect or has spelling mistakes, respond with "Correction: ", followed by the corrected version. If you make a correction, write the whole corrected text, not just the segments with corrections. Do not add additional text or explanations. Do not change special commands, code, escape characters, or mathematical formulas. Only correct grammatical issues, do not change the content:\n{text}';
+		return template.replace('{language}', this.getLanguage()).replace('{text}', text);
 	}
 
 	private getRewritePrompt(text: string): string {
 		const config = vscode.workspace.getConfiguration('lmWritingTool.prompts');
 		const template = config.get<string>('rewrite') ||
-			'Rewrite the following text for clarity in American English. Do not change special commands, code, escape characters, or mathematical formulas. Respond just with the rewritten version of the text, no extra explanation:\n{text}';
-		return template.replace('{text}', text);
+			'Rewrite the following text for clarity in {language}. Do not change special commands, code, escape characters, or mathematical formulas. Respond just with the rewritten version of the text, no extra explanation:\n{text}';
+		return template.replace('{language}', this.getLanguage()).replace('{text}', text);
 	}
 
 	private getSynonymsPrompt(expression: string): string {
 		const config = vscode.workspace.getConfiguration('lmWritingTool.prompts');
 		const template = config.get<string>('synonyms') ||
-			'Give up to 5 synonyms for the expression "{expression}". Just respond with the synonyms, separated by newlines. No extra explanation or context needed.';
-		return template.replace('{expression}', expression);
+			'Give up to 5 synonyms in {language} for the expression "{expression}". Just respond with the synonyms, separated by newlines. No extra explanation or context needed.';
+		return template.replace('{language}', this.getLanguage()).replace('{expression}', expression);
 	}
 	async getFullResponse(prompt: string, token: vscode.CancellationToken): Promise<string | undefined> {
 		try {
@@ -552,6 +557,49 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 
 	context.subscriptions.push(
+		vscode.commands.registerCommand('lm-writing-tool.selectLanguage', async () => {
+			const commonLanguages = [
+				'American English',
+				'British English',
+				'German',
+				'French',
+				'Spanish',
+				'Italian',
+				'Portuguese',
+				'Dutch',
+				'Polish',
+				'Russian',
+				'Chinese',
+				'Japanese',
+				'Korean',
+				'Other (enter manually)',
+			];
+			const pick = await vscode.window.showQuickPick(commonLanguages, {
+				placeHolder: 'Select the language to check and write in',
+			});
+			if (!pick) {
+				return;
+			}
+			let language = pick;
+			if (pick === 'Other (enter manually)') {
+				const custom = await vscode.window.showInputBox({
+					prompt: 'Enter the language to use (e.g. "Brazilian Portuguese")',
+					placeHolder: 'Language',
+				});
+				if (!custom) {
+					return;
+				}
+				language = custom.trim();
+			}
+			await vscode.workspace.getConfiguration('lmWritingTool').update('language', language, vscode.ConfigurationTarget.Global);
+			if (_lmwt) {
+				_lmwt.diagnosticsCache.clear();
+			}
+			vscode.window.showInformationMessage(`LLM Writing Tool language set to: ${language}`);
+		})
+	);
+
+	context.subscriptions.push(
 		vscode.commands.registerCommand('lm-writing-tool.resetPrompts', async () => {
 			const config = vscode.workspace.getConfiguration('lmWritingTool.prompts');
 
@@ -576,6 +624,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
 			// Reset Ollama model to default
 			await ollamaConfig.update('model', undefined, vscode.ConfigurationTarget.Global);
+
+			// Reset language to default
+			await vscode.workspace.getConfiguration('lmWritingTool').update('language', undefined, vscode.ConfigurationTarget.Global);
 
 			vscode.window.showInformationMessage('All extension settings have been reset to their default values');
 		})

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,6 +167,11 @@ class LMWritingTool {
 			return this.diagnosticsCache.get(snippet) || {};
 		}
 		const diagnostic = await this.getTextSnippetDiagnostic(snippet, token);
+		// Don't cache results from a request that was cancelled (e.g. by a language change),
+		// otherwise a late response could repopulate the cache with stale-language results.
+		if (token.isCancellationRequested) {
+			return;
+		}
 		this.diagnosticsCache.set(snippet, diagnostic);
 	}
 
@@ -643,8 +648,10 @@ export async function activate(context: vscode.ExtensionContext) {
 			// Reset Ollama model to default
 			await ollamaConfig.update('model', undefined, vscode.ConfigurationTarget.Global);
 
-			// Reset language to default
-			await vscode.workspace.getConfiguration('lmWritingTool').update('language', undefined, vscode.ConfigurationTarget.Global);
+			// Reset language to default in both user and workspace scopes (it may be set in either).
+			const languageConfig = vscode.workspace.getConfiguration('lmWritingTool');
+			await languageConfig.update('language', undefined, vscode.ConfigurationTarget.Global);
+			await languageConfig.update('language', undefined, vscode.ConfigurationTarget.Workspace);
 
 			// Discard cached results and pending work so they are recomputed with the restored language.
 			invalidateDiagnostics();


### PR DESCRIPTION
## Summary
- Closes #5.
- Adds a `lmWritingTool.language` setting (default `American English`).
- Adds a **"LLM writing tool: Select language"** command (common languages + custom entry).
- Makes the default prompts language-aware via a `{language}` placeholder, so any language the model supports can be used without editing prompts.
- Resets language with the existing "Reset all settings" command; clears the diagnostics cache when the language changes.

## Test plan
- [ ] Run "Select language" → German, check a German sentence, verify corrections are in German.
- [ ] Custom language entry works.
- [ ] Existing custom prompts (without `{language}`) still work unchanged.

Made with [Cursor](https://cursor.com)