### PR TITLE
feat: option to check only delimited (quoted) text (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ The extension now supports configurable system prompts and Ollama model selectio
   *Default*: `llama3.2:3b`  
   *Examples*: `llama3.2:1b`, `llama3.1:8b`, `codellama:7b`, `mistral:7b`
 
+**Scope Configuration:**
+
+- **`lmWritingTool.checkOnlyDelimited`**  
+  When enabled, only the text enclosed by the configured delimiters is checked (for example, only the text inside quotation marks). Useful when you want to proofread quoted prose or string literals while ignoring the rest of the document.  
+  *Default*: `false`
+
+- **`lmWritingTool.delimiters`**  
+  The delimiters that mark the text to check when `checkOnlyDelimited` is enabled. Use a single character for matching pairs (e.g. `"` matches `"..."`), or two characters for distinct open/close delimiters (e.g. `“”` or `«»`).  
+  *Default*: `["\""]`
+
 ### Placeholders
 
 When customizing prompts, use these placeholders:

--- a/package.json
+++ b/package.json
@@ -76,6 +76,21 @@
           "type": "string",
           "default": "llama3.2:3b",
           "description": "The Ollama model to use for text processing. Make sure the model is available on your local Ollama server."
+        },
+        "lmWritingTool.checkOnlyDelimited": {
+          "type": "boolean",
+          "default": false,
+          "description": "When enabled, only check text enclosed by the delimiters configured in 'lmWritingTool.delimiters' (e.g. text inside quotation marks). Everything outside the delimiters is left untouched."
+        },
+        "lmWritingTool.delimiters": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "\""
+          ],
+          "description": "Delimiters that mark the text to check when 'lmWritingTool.checkOnlyDelimited' is enabled. Use a single character for matching pairs (e.g. \" matches \"...\"), or two characters for distinct open/close delimiters (e.g. “” or «»)."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ type DelimiterPair = { open: string; close: string };
 
 function parseDelimiters(raw: string[]): DelimiterPair[] {
 	return raw
-		.filter(d => d.length > 0)
+		.filter((d): d is string => typeof d === 'string' && d.length > 0)
 		.map(d => d.length >= 2 ? { open: d[0], close: d[d.length - 1] } : { open: d, close: d });
 }
 
@@ -155,11 +155,11 @@ class LMWritingTool {
 	private getSplitter(): (text: string) => TextSnippet[] {
 		const config = vscode.workspace.getConfiguration('lmWritingTool');
 		if (config.get<boolean>('checkOnlyDelimited')) {
-			const raw = config.get<string[]>('delimiters') || ['"'];
-			const pairs = parseDelimiters(raw);
-			if (pairs.length > 0) {
-				return (text: string) => splitTextByDelimiters(text, pairs);
-			}
+			const raw = config.get<string[]>('delimiters');
+			const pairs = parseDelimiters(Array.isArray(raw) ? raw : ['"']);
+			// When the option is on, only delimited regions are checked. If no valid
+			// delimiters are configured, nothing is checked (rather than whole lines).
+			return (text: string) => splitTextByDelimiters(text, pairs);
 		}
 		return this.textSplitterFunction;
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,12 +46,26 @@ function offsetPosition(base: vscode.Position, relLine: number, relCol: number):
 }
 
 /**
+ * Returns true if the character at `pos` is escaped, i.e. preceded by an odd
+ * number of consecutive backslashes.
+ */
+function isEscaped(text: string, pos: number): boolean {
+	let backslashes = 0;
+	let k = pos - 1;
+	while (k >= 0 && text[k] === '\\') {
+		backslashes++;
+		k--;
+	}
+	return backslashes % 2 === 1;
+}
+
+/**
  * Finds the next occurrence of `needle` at or after `from` that is not escaped
- * by a preceding backslash.
+ * (not preceded by an odd number of backslashes).
  */
 function indexOfUnescaped(text: string, needle: string, from: number): number {
 	let idx = text.indexOf(needle, from);
-	while (idx > 0 && text[idx - 1] === '\\') {
+	while (idx > 0 && isEscaped(text, idx)) {
 		idx = text.indexOf(needle, idx + needle.length);
 	}
 	return idx;
@@ -67,7 +81,7 @@ function splitTextByDelimiters(text: string, pairs: DelimiterPair[]): TextSnippe
 	let i = 0;
 	while (i < text.length) {
 		const matched = pairs.find(p => text.startsWith(p.open, i));
-		if (!matched) {
+		if (!matched || isEscaped(text, i)) {
 			i++;
 			continue;
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,45 @@ function splitTextByLine(text: string): TextSnippet[] {
 	return snippets;
 }
 
+type DelimiterPair = { open: string; close: string };
+
+function parseDelimiters(raw: string[]): DelimiterPair[] {
+	return raw
+		.filter(d => d.length > 0)
+		.map(d => d.length >= 2 ? { open: d[0], close: d[d.length - 1] } : { open: d, close: d });
+}
+
+/**
+ * Splits text into the regions enclosed by the configured delimiter pairs
+ * (e.g. quotation marks). Only the content between delimiters is returned, so
+ * grammar checking is limited to those regions.
+ */
+function splitTextByDelimiters(text: string, pairs: DelimiterPair[]): TextSnippet[] {
+	const snippets: TextSnippet[] = [];
+	let i = 0;
+	while (i < text.length) {
+		const matched = pairs.find(p => text.startsWith(p.open, i));
+		if (!matched) {
+			i++;
+			continue;
+		}
+		const contentStart = i + matched.open.length;
+		const closeIdx = text.indexOf(matched.close, contentStart);
+		if (closeIdx === -1) {
+			break;
+		}
+		const content = text.substring(contentStart, closeIdx);
+		if (content.trim().length > 0) {
+			const start = getLineCol(text, contentStart);
+			const end = getLineCol(text, closeIdx);
+			const range = new vscode.Range(start.line, start.col, end.line, end.col);
+			snippets.push({ text: content, range });
+		}
+		i = closeIdx + matched.close.length;
+	}
+	return snippets;
+}
+
 type TextSnippetDiagnostic = {
 	correctedVersion?: string;
 	suggestedImprovements?: { explanation: string, improvedVersion: string }[];
@@ -70,6 +109,18 @@ class LMWritingTool {
 		this.corrections = new Map();
 		this.taskScheduler = new TaskScheduler(1);
 		//this.lmCallback = lmCallback;
+	}
+
+	private getSplitter(): (text: string) => TextSnippet[] {
+		const config = vscode.workspace.getConfiguration('lmWritingTool');
+		if (config.get<boolean>('checkOnlyDelimited')) {
+			const raw = config.get<string[]>('delimiters') || ['"'];
+			const pairs = parseDelimiters(raw);
+			if (pairs.length > 0) {
+				return (text: string) => splitTextByDelimiters(text, pairs);
+			}
+		}
+		return this.textSplitterFunction;
 	}
 
 	private getProofreadingPrompt(text: string): string {
@@ -167,7 +218,7 @@ class LMWritingTool {
 
 	getCachedSnippetDiagnosticsAtLocation(document: vscode.TextDocument, location: vscode.Position): LocatedTextSnippetDiagnostic[] {
 		const text = document.getText();
-		const snippets = this.textSplitterFunction(text);
+		const snippets = this.getSplitter()(text);
 		const snippetsAtLocation = snippets.filter(s => s.range.contains(location));
 
 		return snippetsAtLocation.map(s => {
@@ -182,7 +233,7 @@ class LMWritingTool {
 	}
 	sendLLMRequestsForDocument(document: vscode.TextDocument) {
 		const text = document.getText();
-		const snippets = this.textSplitterFunction(text);
+		const snippets = this.getSplitter()(text);
 		const snippetTexts = [...new Set(snippets.map(s => s.text))];
 		const currentlyActiveDocument = vscode.window.activeTextEditor?.document.uri.toString();
 		for (const [id, t] of this.taskScheduler.pendingTasks) {
@@ -237,7 +288,7 @@ class LMWritingTool {
 
 	checkDocument(document: vscode.TextDocument): vscode.Diagnostic[] {
 		const text = document.getText();
-		const snippets = splitTextByLine(text);
+		const snippets = this.getSplitter()(text);
 		const snippetTexts = [...new Set(snippets.map(s => s.text))];
 		//await Promise.all(snippetTexts.map((ts) => this.getSnippetDiagnostics(ts)));
 		const newCorrections: LocatedCorrection[] = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,30 @@ function parseDelimiters(raw: string[]): DelimiterPair[] {
 }
 
 /**
+ * Maps a position that is `relLine`/`relCol` into a snippet back to an absolute
+ * document position. On the first snippet line the column is relative to the
+ * snippet start; on subsequent lines it is an absolute column.
+ */
+function offsetPosition(base: vscode.Position, relLine: number, relCol: number): vscode.Position {
+	if (relLine === 0) {
+		return new vscode.Position(base.line, base.character + relCol);
+	}
+	return new vscode.Position(base.line + relLine, relCol);
+}
+
+/**
+ * Finds the next occurrence of `needle` at or after `from` that is not escaped
+ * by a preceding backslash.
+ */
+function indexOfUnescaped(text: string, needle: string, from: number): number {
+	let idx = text.indexOf(needle, from);
+	while (idx > 0 && text[idx - 1] === '\\') {
+		idx = text.indexOf(needle, idx + needle.length);
+	}
+	return idx;
+}
+
+/**
  * Splits text into the regions enclosed by the configured delimiter pairs
  * (e.g. quotation marks). Only the content between delimiters is returned, so
  * grammar checking is limited to those regions.
@@ -48,9 +72,12 @@ function splitTextByDelimiters(text: string, pairs: DelimiterPair[]): TextSnippe
 			continue;
 		}
 		const contentStart = i + matched.open.length;
-		const closeIdx = text.indexOf(matched.close, contentStart);
+		const closeIdx = indexOfUnescaped(text, matched.close, contentStart);
 		if (closeIdx === -1) {
-			break;
+			// No matching close delimiter: skip past this opener and keep scanning
+			// so later well-formed regions are still extracted.
+			i = contentStart;
+			continue;
 		}
 		const content = text.substring(contentStart, closeIdx);
 		if (content.trim().length > 0) {
@@ -300,8 +327,8 @@ class LMWritingTool {
 				for (const correction of corrections) {
 					const { line: startLineRelative, col: startColRelative } = getLineCol(snippet.text, correction.start);
 					const { line: endLineRelative, col: endColRelative } = getLineCol(snippet.text, correction.end);
-					const start = snippet.range.start.translate(startLineRelative, startColRelative);
-					const end = snippet.range.start.translate(endLineRelative, endColRelative);
+					const start = offsetPosition(snippet.range.start, startLineRelative, startColRelative);
+					const end = offsetPosition(snippet.range.start, endLineRelative, endColRelative);
 					const range = new vscode.Range(start, end);
 					const text = correction.toInsert === "" ? "Remove" : `Change to: ${correction.toInsert}`;
 					const diagnostic = new vscode.Diagnostic(range, text, vscode.DiagnosticSeverity.Information);


### PR DESCRIPTION
## Summary
- Closes #11.
- Adds `lmWritingTool.checkOnlyDelimited` (boolean) and `lmWritingTool.delimiters` (array) settings.
- When enabled, only text enclosed by the configured delimiters is proofread (e.g. text inside quotation marks); everything else is ignored.
- Single-character delimiters match pairs (e.g. `"`…`"`); two-character entries define distinct open/close (e.g. `“”`, `«»`).
- Routes all snippet splitting through a shared `getSplitter` helper (also fixes `checkDocument` previously hardcoding line splitting).

## Test plan
- [ ] Enable setting; only quoted regions get diagnostics, with correct ranges and quick fixes.
- [ ] Multi-line quoted regions map corrections correctly.
- [ ] Disabled (default) behaves exactly as before.

Made with [Cursor](https://cursor.com)