### PR TITLE
feat: LaTeX-aware proofreading (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This extension bridges the gap by leveraging large language models (LLMs). It ch
 ![LLM-based grammar checking](resources/demo.gif)  
 
 - **LLM-powered grammar checking** in American English  
+- **LaTeX-aware checking** that proofreads prose while skipping comments, math, and verbatim/code environments  
 - **Inline corrections** via quick fixes  
 - **Choice of models**: Use a local `llama3.2:3b` model via [Ollama](https://ollama.com/) or `gpt-40-mini` through the [VSCode LM API](https://code.visualstudio.com/api/extension-guides/language-model)  
 - **Rewrite suggestions** to improve clarity  
@@ -145,6 +146,17 @@ Set `lmWritingTool.ollama.model` to `llama3.1:8b` for better quality (but slower
 3. **Detected errors are highlighted**, and users can apply quick fixes with a click.  
 4. **Responses are cached** to minimize repeated API calls.  
 5. Every **5 seconds,** the extension checks for text changes and reprocesses modified sections.  
+
+## LaTeX support
+
+When editing a LaTeX document (language mode `latex`), the extension automatically uses a LaTeX-aware splitter that only proofreads natural-language prose. It skips:
+
+- Line comments (`% ...`)
+- Math environments (e.g. `equation`, `align`, `displaymath`) and display math (`\[ ... \]`, `$$ ... $$`)
+- Verbatim/code environments (e.g. `verbatim`, `lstlisting`, `minted`) and `tikzpicture`
+- Structural, prose-free commands (e.g. `\begin{...}`, `\usepackage{...}`, `\label{...}`, `\cite{...}`)
+
+This prevents the model from trying to "correct" formulas, code, or markup, and keeps suggestions focused on your writing.
 
 ## Roadmap  
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Set `lmWritingTool.ollama.model` to `llama3.1:8b` for better quality (but slower
 When editing a LaTeX document (language mode `latex`), the extension automatically uses a LaTeX-aware splitter that only proofreads natural-language prose. It skips:
 
 - Line comments (`% ...`)
-- Math environments (e.g. `equation`, `align`, `displaymath`) and display math (`\[ ... \]`, `$$ ... $$`)
+- Math environments (e.g. `equation`, `align`, `displaymath`), display math (`\[ ... \]`, `$$ ... $$`), and inline math (`$ ... $`, `\( ... \)`)
 - Verbatim/code environments (e.g. `verbatim`, `lstlisting`, `minted`) and `tikzpicture`
 - Structural, prose-free commands (e.g. `\begin{...}`, `\usepackage{...}`, `\label{...}`, `\cite{...}`)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,76 +38,110 @@ const LATEX_SKIP_ENVIRONMENTS = new Set([
 const LATEX_STRUCTURAL_COMMAND = /^\\(begin|end|usepackage|documentclass|input|include|includegraphics|label|ref|eqref|pageref|cite|nocite|bibliography|bibliographystyle|addbibresource|printbibliography|newcommand|renewcommand|providecommand|def|hline|toprule|midrule|bottomrule|centering|raggedright|noindent|clearpage|cleardoublepage|newpage|pagebreak|vspace\*?|hspace\*?|tableofcontents|listoffigures|listoftables|maketitle|appendix|hrule|bigskip|medskip|smallskip)\b/;
 
 /**
- * Removes a trailing LaTeX line comment (the first unescaped `%` to end of line).
+ * Builds a boolean mask over `text` where `true` marks characters that are
+ * natural-language prose and `false` marks characters that should not be
+ * proofread: comments, math/verbatim environments, and display math.
+ *
+ * A single forward scan is used. Regions are only masked when their closing
+ * delimiter is found, so an unclosed environment or math block is treated as
+ * prose rather than swallowing the rest of the document. Verbatim/math contents
+ * are skipped to their literal `\end{...}`, so any `\begin{...}` shown as
+ * example code inside them is ignored.
  */
-function stripLatexComment(line: string): string {
-	for (let i = 0; i < line.length; i++) {
-		if (line[i] === '%' && (i === 0 || line[i - 1] !== '\\')) {
-			return line.substring(0, i);
+function maskLatexProse(text: string): boolean[] {
+	const n = text.length;
+	const mask = new Array<boolean>(n).fill(true);
+	const maskRange = (from: number, to: number) => {
+		for (let k = from; k < to; k++) {
+			mask[k] = false;
 		}
+	};
+
+	let i = 0;
+	while (i < n) {
+		const ch = text[i];
+		if (ch === '%' && (i === 0 || text[i - 1] !== '\\')) {
+			let j = i;
+			while (j < n && text[j] !== '\n') {
+				mask[j] = false;
+				j++;
+			}
+			i = j;
+			continue;
+		}
+		if (text.startsWith('\\begin{', i)) {
+			const braceEnd = text.indexOf('}', i + 7);
+			if (braceEnd !== -1) {
+				const env = text.substring(i + 7, braceEnd);
+				if (LATEX_SKIP_ENVIRONMENTS.has(env)) {
+					const closeTok = `\\end{${env}}`;
+					const closeIdx = text.indexOf(closeTok, braceEnd + 1);
+					if (closeIdx !== -1) {
+						const end = closeIdx + closeTok.length;
+						maskRange(i, end);
+						i = end;
+						continue;
+					}
+				}
+			}
+			i++;
+			continue;
+		}
+		if (text.startsWith('\\[', i)) {
+			const closeIdx = text.indexOf('\\]', i + 2);
+			if (closeIdx !== -1) {
+				maskRange(i, closeIdx + 2);
+				i = closeIdx + 2;
+				continue;
+			}
+			i++;
+			continue;
+		}
+		if (text.startsWith('$$', i)) {
+			const closeIdx = text.indexOf('$$', i + 2);
+			if (closeIdx !== -1) {
+				maskRange(i, closeIdx + 2);
+				i = closeIdx + 2;
+				continue;
+			}
+			i++;
+			continue;
+		}
+		i++;
 	}
-	return line;
+	return mask;
 }
 
 /**
- * Splits LaTeX source into line snippets, skipping content that is not natural
+ * Splits LaTeX source into prose snippets, skipping content that is not natural
  * language: comments, math/verbatim environments, display math, and structural
- * commands. This keeps the proofreader focused on prose and avoids mangling code.
+ * commands. Each contiguous run of prose on a line becomes its own snippet, so
+ * prose that shares a line with skipped markup is still checked.
  */
 function splitLatex(text: string): TextSnippet[] {
 	const snippets: TextSnippet[] = [];
+	const mask = maskLatexProse(text);
 	const lines = text.split('\n');
-	let skipDepth = 0;
-	let inDisplayMath = false;
-	const beginEndRe = /\\(begin|end)\{([^}]*)\}/g;
-
+	let offset = 0;
 	for (let line = 0; line < lines.length; line++) {
-		const skippingAtLineStart = skipDepth > 0 || inDisplayMath;
-		const content = stripLatexComment(lines[line]);
-
-		beginEndRe.lastIndex = 0;
-		let match: RegExpExecArray | null;
-		while ((match = beginEndRe.exec(content)) !== null) {
-			const [, kind, env] = match;
-			if (!LATEX_SKIP_ENVIRONMENTS.has(env)) {
+		const l = lines[line];
+		let col = 0;
+		while (col < l.length) {
+			if (!mask[offset + col]) {
+				col++;
 				continue;
 			}
-			if (kind === 'begin') {
-				skipDepth++;
-			} else {
-				skipDepth = Math.max(0, skipDepth - 1);
+			const runStart = col;
+			while (col < l.length && mask[offset + col]) {
+				col++;
+			}
+			const runText = l.substring(runStart, col);
+			const trimmed = runText.trim();
+			if (trimmed.length > 0 && /[a-zA-Z]/.test(trimmed) && !LATEX_STRUCTURAL_COMMAND.test(trimmed)) {
+				snippets.push({ text: runText, range: new vscode.Range(line, runStart, line, col) });
 			}
 		}
-
-		const trimmed = content.trim();
-		const opensDisplayMath = (content.split('\\[').length - 1) > (content.split('\\]').length - 1)
-			|| ((content.split('$$').length - 1) % 2 === 1);
-		const closesDisplayMath = (content.split('\\]').length - 1) > (content.split('\\[').length - 1)
-			|| ((content.split('$$').length - 1) % 2 === 1);
-		if (!inDisplayMath && opensDisplayMath) {
-			inDisplayMath = true;
-		} else if (inDisplayMath && closesDisplayMath) {
-			inDisplayMath = false;
-		}
-
-		if (skippingAtLineStart) {
-			continue;
-		}
-		if (trimmed.length === 0) {
-			continue;
-		}
-		if (trimmed.startsWith('%')) {
-			continue;
-		}
-		if (LATEX_STRUCTURAL_COMMAND.test(trimmed)) {
-			continue;
-		}
-		if (!/[a-zA-Z]/.test(trimmed)) {
-			continue;
-		}
-
-		const range = new vscode.Range(line, 0, line, content.length);
-		snippets.push({ text: content, range });
+		offset += l.length + 1;
 	}
 	return snippets;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,25 +66,23 @@ function maskLatexProse(text: string): boolean[] {
 			mask[k] = false;
 		}
 	};
-	// Masks a balanced {...} or [...] group starting at `start`; returns the index after it.
-	const maskBalancedGroup = (start: number): number => {
+	// Finds the index just after the balanced {...} or [...] group starting at `start`,
+	// or -1 if it is never closed (so callers can avoid masking the rest of the file).
+	const findGroupEnd = (start: number): number => {
 		const open = text[start];
 		const close = open === '{' ? '}' : ']';
 		let depth = 0;
-		let k = start;
-		for (; k < n; k++) {
-			mask[k] = false;
+		for (let k = start; k < n; k++) {
 			if (text[k] === open) {
 				depth++;
 			} else if (text[k] === close) {
 				depth--;
 				if (depth === 0) {
-					k++;
-					break;
+					return k + 1;
 				}
 			}
 		}
-		return k;
+		return -1;
 	};
 
 	let i = 0;
@@ -209,7 +207,13 @@ function maskLatexProse(text: string): boolean[] {
 			if (LATEX_STRUCTURAL_NAMES.has(name)) {
 				maskRange(i, k);
 				while (k < n && (text[k] === '{' || text[k] === '[')) {
-					k = maskBalancedGroup(k);
+					const groupEnd = findGroupEnd(k);
+					if (groupEnd === -1) {
+						// Unclosed argument: stop here rather than masking the rest of the file.
+						break;
+					}
+					maskRange(k, groupEnd);
+					k = groupEnd;
 				}
 				i = k;
 				continue;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,29 @@ function maskLatexProse(text: string): boolean[] {
 			mask[k] = false;
 		}
 	};
+	// Precompute which characters belong to a `%` line comment so token searches can
+	// ignore e.g. a literal \end{equation} written inside a comment.
+	const inComment = new Array<boolean>(n).fill(false);
+	for (let p = 0; p < n;) {
+		if (text[p] === '%' && (p === 0 || text[p - 1] !== '\\')) {
+			let q = p;
+			while (q < n && text[q] !== '\n') {
+				inComment[q] = true;
+				q++;
+			}
+			p = q;
+		} else {
+			p++;
+		}
+	}
+	// Like indexOf, but skips matches that fall inside a comment.
+	const indexOfOutsideComment = (token: string, from: number): number => {
+		let idx = text.indexOf(token, from);
+		while (idx !== -1 && inComment[idx]) {
+			idx = text.indexOf(token, idx + 1);
+		}
+		return idx;
+	};
 	// Finds the index just after the balanced {...} or [...] group starting at `start`,
 	// or -1 if it is never closed (so callers can avoid masking the rest of the file).
 	const findGroupEnd = (start: number): number => {
@@ -109,8 +132,8 @@ function maskLatexProse(text: string): boolean[] {
 					let search = braceEnd + 1;
 					let end = -1;
 					while (search < n) {
-						const nextBegin = text.indexOf(beginTok, search);
-						const nextEnd = text.indexOf(endTok, search);
+						const nextBegin = indexOfOutsideComment(beginTok, search);
+						const nextEnd = indexOfOutsideComment(endTok, search);
 						if (nextEnd === -1) {
 							break;
 						}
@@ -152,7 +175,7 @@ function maskLatexProse(text: string): boolean[] {
 			continue;
 		}
 		if (text.startsWith('\\[', i)) {
-			const closeIdx = text.indexOf('\\]', i + 2);
+			const closeIdx = indexOfOutsideComment('\\]', i + 2);
 			if (closeIdx !== -1) {
 				maskRange(i, closeIdx + 2);
 				i = closeIdx + 2;
@@ -162,7 +185,7 @@ function maskLatexProse(text: string): boolean[] {
 			continue;
 		}
 		if (text.startsWith('\\(', i)) {
-			const closeIdx = text.indexOf('\\)', i + 2);
+			const closeIdx = indexOfOutsideComment('\\)', i + 2);
 			if (closeIdx !== -1) {
 				maskRange(i, closeIdx + 2);
 				i = closeIdx + 2;
@@ -172,7 +195,7 @@ function maskLatexProse(text: string): boolean[] {
 			continue;
 		}
 		if (text.startsWith('$$', i)) {
-			const closeIdx = text.indexOf('$$', i + 2);
+			const closeIdx = indexOfOutsideComment('$$', i + 2);
 			if (closeIdx !== -1) {
 				maskRange(i, closeIdx + 2);
 				i = closeIdx + 2;
@@ -182,9 +205,9 @@ function maskLatexProse(text: string): boolean[] {
 			continue;
 		}
 		if (ch === '$' && (i === 0 || text[i - 1] !== '\\')) {
-			// Inline math: find the next unescaped closing dollar.
+			// Inline math: find the next unescaped closing dollar that is not in a comment.
 			let j = i + 1;
-			while (j < n && !(text[j] === '$' && text[j - 1] !== '\\')) {
+			while (j < n && !(text[j] === '$' && text[j - 1] !== '\\' && !inComment[j])) {
 				j++;
 			}
 			if (j < n) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,8 +34,18 @@ const LATEX_SKIP_ENVIRONMENTS = new Set([
 	'lstlisting', 'minted', 'tikzpicture', 'pgfpicture',
 ]);
 
-// Structural LaTeX commands that occupy a whole line and contain no prose to check.
-const LATEX_STRUCTURAL_COMMAND = /^\\(begin|end|usepackage|documentclass|input|include|includegraphics|label|ref|eqref|pageref|cite|nocite|bibliography|bibliographystyle|addbibresource|printbibliography|newcommand|renewcommand|providecommand|def|hline|toprule|midrule|bottomrule|centering|raggedright|noindent|clearpage|cleardoublepage|newpage|pagebreak|vspace\*?|hspace\*?|tableofcontents|listoffigures|listoftables|maketitle|appendix|hrule|bigskip|medskip|smallskip)\b/;
+// Structural LaTeX commands that contain no prose to check. Their command token and
+// any immediately following [...] / {...} arguments are masked, so prose that shares a
+// line with them is still proofread (\begin and \end are handled separately).
+const LATEX_STRUCTURAL_NAMES = new Set([
+	'usepackage', 'documentclass', 'input', 'include', 'includegraphics', 'label',
+	'ref', 'eqref', 'pageref', 'cite', 'nocite', 'bibliography', 'bibliographystyle',
+	'addbibresource', 'printbibliography', 'newcommand', 'renewcommand', 'providecommand',
+	'def', 'hline', 'toprule', 'midrule', 'bottomrule', 'centering', 'raggedright',
+	'noindent', 'clearpage', 'cleardoublepage', 'newpage', 'pagebreak', 'vspace', 'hspace',
+	'tableofcontents', 'listoffigures', 'listoftables', 'maketitle', 'appendix', 'hrule',
+	'bigskip', 'medskip', 'smallskip',
+]);
 
 /**
  * Builds a boolean mask over `text` where `true` marks characters that are
@@ -55,6 +65,26 @@ function maskLatexProse(text: string): boolean[] {
 		for (let k = from; k < to; k++) {
 			mask[k] = false;
 		}
+	};
+	// Masks a balanced {...} or [...] group starting at `start`; returns the index after it.
+	const maskBalancedGroup = (start: number): number => {
+		const open = text[start];
+		const close = open === '{' ? '}' : ']';
+		let depth = 0;
+		let k = start;
+		for (; k < n; k++) {
+			mask[k] = false;
+			if (text[k] === open) {
+				depth++;
+			} else if (text[k] === close) {
+				depth--;
+				if (depth === 0) {
+					k++;
+					break;
+				}
+			}
+		}
+		return k;
 	};
 
 	let i = 0;
@@ -103,7 +133,22 @@ function maskLatexProse(text: string): boolean[] {
 						i = end;
 						continue;
 					}
+				} else {
+					// Non-skip environment: mask just the \begin{env} token, keep its body as prose.
+					maskRange(i, braceEnd + 1);
+					i = braceEnd + 1;
+					continue;
 				}
+			}
+			i++;
+			continue;
+		}
+		if (text.startsWith('\\end{', i)) {
+			const braceEnd = text.indexOf('}', i + 5);
+			if (braceEnd !== -1) {
+				maskRange(i, braceEnd + 1);
+				i = braceEnd + 1;
+				continue;
 			}
 			i++;
 			continue;
@@ -152,6 +197,26 @@ function maskLatexProse(text: string): boolean[] {
 			i++;
 			continue;
 		}
+		if (ch === '\\') {
+			let k = i + 1;
+			while (k < n && /[a-zA-Z]/.test(text[k])) {
+				k++;
+			}
+			const name = text.substring(i + 1, k);
+			if (k < n && text[k] === '*') {
+				k++;
+			}
+			if (LATEX_STRUCTURAL_NAMES.has(name)) {
+				maskRange(i, k);
+				while (k < n && (text[k] === '{' || text[k] === '[')) {
+					k = maskBalancedGroup(k);
+				}
+				i = k;
+				continue;
+			}
+			i++;
+			continue;
+		}
 		i++;
 	}
 	return mask;
@@ -182,7 +247,7 @@ function splitLatex(text: string): TextSnippet[] {
 			}
 			const runText = l.substring(runStart, col);
 			const trimmed = runText.trim();
-			if (trimmed.length > 0 && /[a-zA-Z]/.test(trimmed) && !LATEX_STRUCTURAL_COMMAND.test(trimmed)) {
+			if (trimmed.length > 0 && /[a-zA-Z]/.test(trimmed)) {
 				snippets.push({ text: runText, range: new vscode.Range(line, runStart, line, col) });
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,93 @@ function splitTextByLine(text: string): TextSnippet[] {
 	return snippets;
 }
 
+// LaTeX environments whose contents are not natural-language prose and should not be proofread.
+const LATEX_SKIP_ENVIRONMENTS = new Set([
+	'equation', 'equation*', 'align', 'align*', 'alignat', 'alignat*',
+	'gather', 'gather*', 'multline', 'multline*', 'displaymath', 'math',
+	'eqnarray', 'eqnarray*', 'array', 'matrix', 'pmatrix', 'bmatrix',
+	'vmatrix', 'Vmatrix', 'smallmatrix', 'cases', 'verbatim', 'Verbatim',
+	'lstlisting', 'minted', 'tikzpicture', 'pgfpicture',
+]);
+
+// Structural LaTeX commands that occupy a whole line and contain no prose to check.
+const LATEX_STRUCTURAL_COMMAND = /^\\(begin|end|usepackage|documentclass|input|include|includegraphics|label|ref|eqref|pageref|cite|nocite|bibliography|bibliographystyle|addbibresource|printbibliography|newcommand|renewcommand|providecommand|def|hline|toprule|midrule|bottomrule|centering|raggedright|noindent|clearpage|cleardoublepage|newpage|pagebreak|vspace\*?|hspace\*?|tableofcontents|listoffigures|listoftables|maketitle|appendix|hrule|bigskip|medskip|smallskip)\b/;
+
+/**
+ * Removes a trailing LaTeX line comment (the first unescaped `%` to end of line).
+ */
+function stripLatexComment(line: string): string {
+	for (let i = 0; i < line.length; i++) {
+		if (line[i] === '%' && (i === 0 || line[i - 1] !== '\\')) {
+			return line.substring(0, i);
+		}
+	}
+	return line;
+}
+
+/**
+ * Splits LaTeX source into line snippets, skipping content that is not natural
+ * language: comments, math/verbatim environments, display math, and structural
+ * commands. This keeps the proofreader focused on prose and avoids mangling code.
+ */
+function splitLatex(text: string): TextSnippet[] {
+	const snippets: TextSnippet[] = [];
+	const lines = text.split('\n');
+	let skipDepth = 0;
+	let inDisplayMath = false;
+	const beginEndRe = /\\(begin|end)\{([^}]*)\}/g;
+
+	for (let line = 0; line < lines.length; line++) {
+		const skippingAtLineStart = skipDepth > 0 || inDisplayMath;
+		const content = stripLatexComment(lines[line]);
+
+		beginEndRe.lastIndex = 0;
+		let match: RegExpExecArray | null;
+		while ((match = beginEndRe.exec(content)) !== null) {
+			const [, kind, env] = match;
+			if (!LATEX_SKIP_ENVIRONMENTS.has(env)) {
+				continue;
+			}
+			if (kind === 'begin') {
+				skipDepth++;
+			} else {
+				skipDepth = Math.max(0, skipDepth - 1);
+			}
+		}
+
+		const trimmed = content.trim();
+		const opensDisplayMath = (content.split('\\[').length - 1) > (content.split('\\]').length - 1)
+			|| ((content.split('$$').length - 1) % 2 === 1);
+		const closesDisplayMath = (content.split('\\]').length - 1) > (content.split('\\[').length - 1)
+			|| ((content.split('$$').length - 1) % 2 === 1);
+		if (!inDisplayMath && opensDisplayMath) {
+			inDisplayMath = true;
+		} else if (inDisplayMath && closesDisplayMath) {
+			inDisplayMath = false;
+		}
+
+		if (skippingAtLineStart) {
+			continue;
+		}
+		if (trimmed.length === 0) {
+			continue;
+		}
+		if (trimmed.startsWith('%')) {
+			continue;
+		}
+		if (LATEX_STRUCTURAL_COMMAND.test(trimmed)) {
+			continue;
+		}
+		if (!/[a-zA-Z]/.test(trimmed)) {
+			continue;
+		}
+
+		const range = new vscode.Range(line, 0, line, content.length);
+		snippets.push({ text: content, range });
+	}
+	return snippets;
+}
+
 type TextSnippetDiagnostic = {
 	correctedVersion?: string;
 	suggestedImprovements?: { explanation: string, improvedVersion: string }[];
@@ -70,6 +157,13 @@ class LMWritingTool {
 		this.corrections = new Map();
 		this.taskScheduler = new TaskScheduler(1);
 		//this.lmCallback = lmCallback;
+	}
+
+	private getSplitter(document: vscode.TextDocument): (text: string) => TextSnippet[] {
+		if (document.languageId === 'latex') {
+			return splitLatex;
+		}
+		return this.textSplitterFunction;
 	}
 
 	private getProofreadingPrompt(text: string): string {
@@ -167,7 +261,7 @@ class LMWritingTool {
 
 	getCachedSnippetDiagnosticsAtLocation(document: vscode.TextDocument, location: vscode.Position): LocatedTextSnippetDiagnostic[] {
 		const text = document.getText();
-		const snippets = this.textSplitterFunction(text);
+		const snippets = this.getSplitter(document)(text);
 		const snippetsAtLocation = snippets.filter(s => s.range.contains(location));
 
 		return snippetsAtLocation.map(s => {
@@ -182,7 +276,7 @@ class LMWritingTool {
 	}
 	sendLLMRequestsForDocument(document: vscode.TextDocument) {
 		const text = document.getText();
-		const snippets = this.textSplitterFunction(text);
+		const snippets = this.getSplitter(document)(text);
 		const snippetTexts = [...new Set(snippets.map(s => s.text))];
 		const currentlyActiveDocument = vscode.window.activeTextEditor?.document.uri.toString();
 		for (const [id, t] of this.taskScheduler.pendingTasks) {
@@ -237,7 +331,7 @@ class LMWritingTool {
 
 	checkDocument(document: vscode.TextDocument): vscode.Diagnostic[] {
 		const text = document.getText();
-		const snippets = splitTextByLine(text);
+		const snippets = this.getSplitter(document)(text);
 		const snippetTexts = [...new Set(snippets.map(s => s.text))];
 		//await Promise.all(snippetTexts.map((ts) => this.getSnippetDiagnostics(ts)));
 		const newCorrections: LocatedCorrection[] = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,10 +74,31 @@ function maskLatexProse(text: string): boolean[] {
 			if (braceEnd !== -1) {
 				const env = text.substring(i + 7, braceEnd);
 				if (LATEX_SKIP_ENVIRONMENTS.has(env)) {
-					const closeTok = `\\end{${env}}`;
-					const closeIdx = text.indexOf(closeTok, braceEnd + 1);
-					if (closeIdx !== -1) {
-						const end = closeIdx + closeTok.length;
+					// Match the closing \end{env} accounting for nested same-name environments.
+					const beginTok = `\\begin{${env}}`;
+					const endTok = `\\end{${env}}`;
+					let depth = 1;
+					let search = braceEnd + 1;
+					let end = -1;
+					while (search < n) {
+						const nextBegin = text.indexOf(beginTok, search);
+						const nextEnd = text.indexOf(endTok, search);
+						if (nextEnd === -1) {
+							break;
+						}
+						if (nextBegin !== -1 && nextBegin < nextEnd) {
+							depth++;
+							search = nextBegin + beginTok.length;
+						} else {
+							depth--;
+							search = nextEnd + endTok.length;
+							if (depth === 0) {
+								end = search;
+								break;
+							}
+						}
+					}
+					if (end !== -1) {
 						maskRange(i, end);
 						i = end;
 						continue;
@@ -97,11 +118,35 @@ function maskLatexProse(text: string): boolean[] {
 			i++;
 			continue;
 		}
+		if (text.startsWith('\\(', i)) {
+			const closeIdx = text.indexOf('\\)', i + 2);
+			if (closeIdx !== -1) {
+				maskRange(i, closeIdx + 2);
+				i = closeIdx + 2;
+				continue;
+			}
+			i++;
+			continue;
+		}
 		if (text.startsWith('$$', i)) {
 			const closeIdx = text.indexOf('$$', i + 2);
 			if (closeIdx !== -1) {
 				maskRange(i, closeIdx + 2);
 				i = closeIdx + 2;
+				continue;
+			}
+			i++;
+			continue;
+		}
+		if (ch === '$' && (i === 0 || text[i - 1] !== '\\')) {
+			// Inline math: find the next unescaped closing dollar.
+			let j = i + 1;
+			while (j < n && !(text[j] === '$' && text[j - 1] !== '\\')) {
+				j++;
+			}
+			if (j < n) {
+				maskRange(i, j + 1);
+				i = j + 1;
 				continue;
 			}
 			i++;


### PR DESCRIPTION
## Summary
- Closes #2.
- Detects LaTeX documents (`languageId === 'latex'`) and uses a dedicated splitter that proofreads only prose.
- Skips: line comments (`%`), math environments (`equation`, `align`, …) and display math (`\[ \]`, `$$`), verbatim/code environments (`verbatim`, `lstlisting`, `minted`, `tikzpicture`), and structural commands (`\begin`, `\usepackage`, `\label`, `\cite`, …).
- Routes splitting through a `getSplitter(document)` helper (also fixes `checkDocument` previously hardcoding line splitting).

## Test plan
- [ ] Open a `.tex` file; prose lines get checked, math/comments/commands do not.
- [ ] Multi-line equation/verbatim blocks are skipped entirely.
- [ ] Non-LaTeX documents are unaffected.

Made with [Cursor](https://cursor.com)